### PR TITLE
Adding retry to systemd service so that the alarmserver will run again when it fails.

### DIFF
--- a/alarmserver/screen@user.service
+++ b/alarmserver/screen@user.service
@@ -7,6 +7,8 @@ Type=simple
 User=%i
 ExecStart=/usr/bin/screen -DmS alarmserver /home/%i/alarmserver/alarmserver.py -c /home/%i/alarmserver/alarmserver.cfg
 ExecStop=/usr/bin/screen -S alarmserver -X quit
+Restart=always
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I've found that alarmserver fails to start when Raspberry Pi reboots and found that it Python code fails to connect to SmartThings as network is not online yet. And any network glitch seems to cause Python code fails. This retry helps as systemd will automatically restart it if the service fails.
